### PR TITLE
feat: Endpoint Kehadiran Peserta (GET /events/:id/participants & PATCH /attendance/:registration_id) (Issue #38)

### DIFF
--- a/backend/src/controllers/eventController.js
+++ b/backend/src/controllers/eventController.js
@@ -271,3 +271,56 @@ exports.deleteEvent = async (req, res, next) => {
     next(err);
   }
 };
+
+// 8. GET /events/:id/participants (Untuk Panitia)
+exports.getEventParticipants = async (req, res, next) => {
+  try {
+    const eventId = req.params.id;
+    const { id: userId, role } = req.user;
+
+    // Pastikan event milik panitia ini (jika bukan admin)
+    if (role !== 'admin') {
+      const { data: event, error: eventError } = await supabase
+        .from('events')
+        .select('id, created_by')
+        .eq('id', eventId)
+        .single();
+        
+      if (eventError || !event || event.created_by !== userId) {
+        return res.status(403).json({
+          status: 'fail',
+          statusCode: 403,
+          message: 'Anda tidak memiliki akses ke event ini.',
+        });
+      }
+    }
+
+    const { data: participants, error } = await supabase
+      .from('registrations')
+      .select(`
+        id,
+        status,
+        registered_at,
+        users (
+          id,
+          name,
+          email,
+          university,
+          major
+        )
+      `)
+      .eq('event_id', eventId)
+      .order('registered_at', { ascending: true });
+
+    if (error) throw error;
+
+    res.status(200).json({
+      status: 'success',
+      statusCode: 200,
+      total: participants.length,
+      data: participants,
+    });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/backend/src/controllers/registrationController.js
+++ b/backend/src/controllers/registrationController.js
@@ -74,8 +74,78 @@ const getMyRegistrations = async (req, res, next) => {
   }
 };
 
+// 3. PATCH /attendance/:registration_id
+const updateAttendance = async (req, res, next) => {
+  try {
+    const { registration_id } = req.params;
+    const { status } = req.body;
+    const { id: userId, role } = req.user;
+
+    const validStatuses = ['attended', 'absent'];
+    if (!status || !validStatuses.includes(status)) {
+      return res.status(400).json({
+        status: 'fail',
+        statusCode: 400,
+        message: `Status kehadiran tidak valid. Gunakan: ${validStatuses.join(', ')}`,
+      });
+    }
+
+    // Ambil registration untuk mengecek event_id (lalu cek kepemilikan event jika bukan admin)
+    const { data: registration, error: regError } = await supabase
+      .from('registrations')
+      .select('id, event_id')
+      .eq('id', registration_id)
+      .single();
+
+    if (regError || !registration) {
+      return res.status(404).json({
+        status: 'fail',
+        statusCode: 404,
+        message: 'Registrasi tidak ditemukan.',
+      });
+    }
+
+    // Cek kepemilikan event jika panitia
+    if (role !== 'admin') {
+      const { data: event, error: eventError } = await supabase
+        .from('events')
+        .select('created_by')
+        .eq('id', registration.event_id)
+        .single();
+        
+      if (eventError || !event || event.created_by !== userId) {
+        return res.status(403).json({
+          status: 'fail',
+          statusCode: 403,
+          message: 'Anda tidak memiliki akses untuk mengubah kehadiran pada event ini.',
+        });
+      }
+    }
+
+    // Update status kehadiran
+    const { data: updatedRegistration, error: updateError } = await supabase
+      .from('registrations')
+      .update({ status })
+      .eq('id', registration_id)
+      .select()
+      .single();
+
+    if (updateError) throw updateError;
+
+    return res.status(200).json({
+      status: 'success',
+      statusCode: 200,
+      message: `Status kehadiran berhasil diubah menjadi ${status}.`,
+      data: updatedRegistration,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
 // Pastikan di-export secara eksplisit seperti ini
 module.exports = {
   registerToEvent,
   getMyRegistrations,
+  updateAttendance,
 };

--- a/backend/src/routes/eventRoutes.js
+++ b/backend/src/routes/eventRoutes.js
@@ -20,6 +20,12 @@ router.get(
   eventController.getManagedEvents
 );
 
+router.get(
+  '/events/:id/participants',
+  authorizeRoles('panitia', 'admin'),
+  eventController.getEventParticipants
+);
+
 // CRUD Event Panitia
 router.post(
   '/panitia/events',

--- a/backend/src/routes/registrationRoutes.js
+++ b/backend/src/routes/registrationRoutes.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const registrationController = require('../controllers/registrationController');
 const { authenticateToken } = require('../middlewares/authMiddleware');
+const { authorizeRoles } = require('../middlewares/roleMiddleware');
 
 // Proteksi seluruh route dengan middleware JWT
 router.use(authenticateToken);
@@ -11,5 +12,12 @@ router.get('/registrations/me', authenticateToken, registrationController.getMyR
 
 // POST /api/v1/events/:id/register
 router.post('/events/:id/register', authenticateToken, registrationController.registerToEvent);
+
+// PATCH /api/v1/attendance/:registration_id
+router.patch(
+  '/attendance/:registration_id',
+  authorizeRoles('panitia', 'admin'),
+  registrationController.updateAttendance
+);
 
 module.exports = router;


### PR DESCRIPTION
## Deskripsi
Pull Request ini menyelesaikan [Task #42] (Issue #38) mengenai Endpoint Kehadiran Peserta.

## Fitur Baru
- **GET /events/:id/participants**: Mengembalikan list registrasi peserta untuk event tertentu (dilengkapi data dari tabel users). Endpoint ini dibatasi hanya untuk panitia penyelenggara dan admin.
- **PATCH /attendance/:registration_id**: Mengubah status kehadiran peserta (contoh: ttended atau bsent). Endpoint ini memvalidasi hak akses panitia terhadap event tersebut.

## Role & Akses
- Middleware uthorizeRoles('panitia', 'admin') telah ditambahkan di kedua endpoint.
- Validasi kepemilikan event: Panitia hanya bisa melihat peserta dan mengubah kehadiran pada event yang dibuatnya sendiri.

Pekerjaan diselesaikan sesuai SOP Workflow Task Management.